### PR TITLE
Use AC_SYS_LARGEFILE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ AC_TYPE_UINT8_T
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([getpagesize memset strchr strdup strerror strtoul])
 
+# Configure system services.
+AC_SYS_LARGEFILE
+
 AC_CONFIG_FILES([Makefile
                  man/Makefile
                  src/Makefile

--- a/src/l64seek.c
+++ b/src/l64seek.c
@@ -14,6 +14,7 @@
  *
  */
 
+#include "config.h" /* for large file support */
 #include "l64seek.h"
 
 


### PR DESCRIPTION
On some systems such as 32-bit, x86 GNU/Linux, lseek works with a 32-bit
off_t by default and can be switched to 64-bit variants by defining a
special macro (e.g. '#define _FILE_OFFSET_BITS 64' for 32-bit GNU/Linux).

Add AC_SYS_LARGEFILE to "configure.ac" so that the large file support
macros get defined in the "config.h" header if they are needed.  Change
"l64seek.c" to include the "config.h" header to pick up these macros.
"config.h" needs to be included before "l64seek.h".  "gpart.h" already
does that, but "l64seek.c" doesn't use "gpart.h".