### PR TITLE
Add LVM2 and Btrfs support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@ AM_CFLAGS = -Wall -O2
 AM_LDFLAGS =
 
 sbin_PROGRAMS = gpart
-gpart_SOURCES = disku.c gm_beos.c gm_bsddl.c gm_ext2.c gm_fat.c gm_hmlvm.c gm_hpfs.c gm_lswap.c gm_minix.c gm_ntfs.c gmodules.c gm_qnx4.c gm_reiserfs.c gm_s86dl.c gm_xfs.c gpart.c l64seek.c
-EXTRA_DIST = errmsgs.h gm_bsddl.h gm_fat.h gm_hpfs.h gm_ntfs.h gm_qnx4.h gm_s86dl.h gpart.h gm_beos.h gm_ext2.h gm_hmlvm.h gm_minix.h gmodules.h gm_reiserfs.h gm_xfs.h l64seek.h
+gpart_SOURCES = disku.c gm_beos.c gm_bsddl.c gm_ext2.c gm_fat.c gm_hmlvm.c gm_lvm2.c gm_hpfs.c gm_lswap.c gm_minix.c gm_ntfs.c gmodules.c gm_qnx4.c gm_reiserfs.c gm_s86dl.c gm_xfs.c gpart.c l64seek.c
+EXTRA_DIST = errmsgs.h gm_bsddl.h gm_fat.h gm_hpfs.h gm_ntfs.h gm_qnx4.h gm_s86dl.h gpart.h gm_beos.h gm_ext2.h gm_hmlvm.h gm_lvm2.h gm_minix.h gmodules.h gm_reiserfs.h gm_xfs.h l64seek.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@ AM_CFLAGS = -Wall -O2
 AM_LDFLAGS =
 
 sbin_PROGRAMS = gpart
-gpart_SOURCES = disku.c gm_beos.c gm_bsddl.c gm_ext2.c gm_fat.c gm_hmlvm.c gm_lvm2.c gm_hpfs.c gm_lswap.c gm_minix.c gm_ntfs.c gmodules.c gm_qnx4.c gm_reiserfs.c gm_s86dl.c gm_xfs.c gpart.c l64seek.c
-EXTRA_DIST = errmsgs.h gm_bsddl.h gm_fat.h gm_hpfs.h gm_ntfs.h gm_qnx4.h gm_s86dl.h gpart.h gm_beos.h gm_ext2.h gm_hmlvm.h gm_lvm2.h gm_minix.h gmodules.h gm_reiserfs.h gm_xfs.h l64seek.h
+gpart_SOURCES = disku.c gm_beos.c gm_bsddl.c gm_ext2.c gm_btrfs.c gm_fat.c gm_hmlvm.c gm_lvm2.c gm_hpfs.c gm_lswap.c gm_minix.c gm_ntfs.c gmodules.c gm_qnx4.c gm_reiserfs.c gm_s86dl.c gm_xfs.c gpart.c l64seek.c
+EXTRA_DIST = errmsgs.h gm_bsddl.h gm_fat.h gm_hpfs.h gm_ntfs.h gm_qnx4.h gm_s86dl.h gpart.h gm_beos.h gm_ext2.h gm_btrfs.h gm_hmlvm.h gm_lvm2.h gm_minix.h gmodules.h gm_reiserfs.h gm_xfs.h l64seek.h

--- a/src/gm_btrfs.c
+++ b/src/gm_btrfs.c
@@ -1,0 +1,74 @@
+/*
+ * gm_btrfs.c -- gpart Linux Btrfs volume guessing module
+ *
+ * gpart (c) 1999-2001 Michail Brzitwa <mb@ichabod.han.de>
+ * Guess PC-type hard disk partitions.
+ *
+ * gpart is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2, or (at your
+ * option) any later version.
+ *
+ * Created:   20.11.2015 <mwilck@arcor.de>
+ *
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <endian.h>
+#include "gpart.h"
+#include "gm_btrfs.h"
+
+
+int btrfs_init(disk_desc *d,g_module *m)
+{
+	if ((d == 0) || (m == 0))
+		return (0);
+
+	m->m_desc = "Btrfs volume";
+	return BTRFS_SUPER_INFO_OFFSET + BTRFS_SUPER_INFO_SIZE;
+}
+
+int btrfs_term(disk_desc *d)
+{
+	return (1);
+}
+
+int btrfs_gfun(disk_desc *d,g_module *m)
+{
+	struct btrfs_super_block *sb;
+	dos_part_entry *pt = &m->m_part;
+	s64_t psize;
+
+	m->m_guess = GM_NO;
+	sb = (struct btrfs_super_block*)
+		(d->d_sbuf + BTRFS_SUPER_INFO_OFFSET);
+
+	if (le64toh(sb->magic) != BTRFS_MAGIC)
+		return 1;
+
+	if (memcmp(sb->fsid, sb->dev_item.fsid, BTRFS_FSID_SIZE))
+		return 1;
+
+	psize = le64toh(sb->dev_item.total_bytes);
+	if (psize > btrfs_sb_offset(1)) {
+		struct btrfs_super_block sb_copy;
+		if (l64seek(d->d_fd,
+			    d->d_nsb * d->d_ssize + btrfs_sb_offset(1),
+			    SEEK_SET) == -1)
+			pr(FATAL,"btrfs: cannot seek: %s", strerror(errno));
+		read(d->d_fd, &sb_copy, sizeof(sb_copy));
+		if (le64toh(sb_copy.magic) != BTRFS_MAGIC ||
+		    memcmp(sb->fsid, sb_copy.fsid, BTRFS_FSID_SIZE)) {
+			pr(MSG,"btrfs: superblock copy mismatch\n");
+			return 1;
+		}
+	}
+
+	m->m_guess = GM_YES;
+	pt->p_start = d->d_nsb;
+	pt->p_size = psize / d->d_ssize;
+	pt->p_typ = 0x83;
+
+	return 1;
+}

--- a/src/gm_btrfs.h
+++ b/src/gm_btrfs.h
@@ -1,0 +1,175 @@
+/*
+ * gm_btrfs.h -- gpart Btrfs volume guessing module header
+ *
+ * gpart (c) 1999-2001 Michail Brzitwa <mb@ichabod.han.de>
+ * Guess PC-type hard disk partitions.
+ *
+ * gpart is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2, or (at your
+ * option) any later version.
+ *
+ * Created:   20.11.2015 <mwilck@arcor.de>
+ * Modified:
+ *
+ */
+
+#ifndef _GM_BTRFS_H
+#define _GM_BTRFS_H
+
+/*
+ * structs & defines gathered from btrfs-progs
+ */
+
+#if !defined(__FreeBSD__)
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+#endif
+
+typedef uint64_t __le64;
+typedef uint32_t __le32;
+typedef uint16_t __le16;
+typedef uint8_t u8;
+
+#define BTRFS_SUPER_INFO_OFFSET (64 * 1024)
+#define BTRFS_SUPER_INFO_SIZE 4096
+#define btrfs_sb_offset(i) ((i) ? ((16*1024) << (BTRFS_SUPER_MIRROR_SHIFT * (i))) : BTRFS_SUPER_INFO_SIZE)
+#define BTRFS_SUPER_MIRROR_SHIFT 12
+#define BTRFS_CSUM_SIZE 32
+#define BTRFS_FSID_SIZE 16
+#define BTRFS_UUID_SIZE 16
+#define BTRFS_MAGIC 0x4D5F53665248425FULL
+#define BTRFS_SYSTEM_CHUNK_ARRAY_SIZE 2048
+#define BTRFS_LABEL_SIZE 256
+
+#define BTRFS_NUM_BACKUP_ROOTS 4
+struct btrfs_root_backup {
+	__le64 tree_root;
+	__le64 tree_root_gen;
+
+	__le64 chunk_root;
+	__le64 chunk_root_gen;
+
+	__le64 extent_root;
+	__le64 extent_root_gen;
+
+	__le64 fs_root;
+	__le64 fs_root_gen;
+
+	__le64 dev_root;
+	__le64 dev_root_gen;
+
+	__le64 csum_root;
+	__le64 csum_root_gen;
+
+	__le64 total_bytes;
+	__le64 bytes_used;
+	__le64 num_devices;
+	/* future */
+	__le64 unsed_64[4];
+
+	u8 tree_root_level;
+	u8 chunk_root_level;
+	u8 extent_root_level;
+	u8 fs_root_level;
+	u8 dev_root_level;
+	u8 csum_root_level;
+	/* future and to align */
+	u8 unused_8[10];
+} __attribute__ ((__packed__));
+
+#define BTRFS_UUID_SIZE 16
+struct btrfs_dev_item {
+	/* the internal btrfs device id */
+	__le64 devid;
+
+	/* size of the device */
+	__le64 total_bytes;
+
+	/* bytes used */
+	__le64 bytes_used;
+
+	/* optimal io alignment for this device */
+	__le32 io_align;
+
+	/* optimal io width for this device */
+	__le32 io_width;
+
+	/* minimal io size for this device */
+	__le32 sector_size;
+
+	/* type and info about this device */
+	__le64 type;
+
+	/* expected generation for this device */
+	__le64 generation;
+
+	/*
+	 * starting byte of this partition on the device,
+	 * to allowr for stripe alignment in the future
+	 */
+	__le64 start_offset;
+
+	/* grouping information for allocation decisions */
+	__le32 dev_group;
+
+	/* seek speed 0-100 where 100 is fastest */
+	u8 seek_speed;
+
+	/* bandwidth 0-100 where 100 is fastest */
+	u8 bandwidth;
+
+	/* btrfs generated uuid for this device */
+	u8 uuid[BTRFS_UUID_SIZE];
+
+	/* uuid of FS who owns this device */
+	u8 fsid[BTRFS_UUID_SIZE];
+} __attribute__ ((__packed__));
+
+struct btrfs_super_block {
+	u8 csum[BTRFS_CSUM_SIZE];
+	/* the first 3 fields must match struct btrfs_header */
+	u8 fsid[BTRFS_FSID_SIZE];    /* FS specific uuid */
+	__le64 bytenr; /* this block number */
+	__le64 flags;
+	/* allowed to be different from the btrfs_header from here own down */
+	__le64 magic;
+	__le64 generation;
+	__le64 root;
+	__le64 chunk_root;
+	__le64 log_root;
+
+	/* this will help find the new super based on the log root */
+	__le64 log_root_transid;
+	__le64 total_bytes;
+	__le64 bytes_used;
+	__le64 root_dir_objectid;
+	__le64 num_devices;
+	__le32 sectorsize;
+	__le32 nodesize;
+	__le32 leafsize;
+	__le32 stripesize;
+	__le32 sys_chunk_array_size;
+	__le64 chunk_root_generation;
+	__le64 compat_flags;
+	__le64 compat_ro_flags;
+	__le64 incompat_flags;
+	__le16 csum_type;
+	u8 root_level;
+	u8 chunk_root_level;
+	u8 log_root_level;
+	struct btrfs_dev_item dev_item;
+
+	char label[BTRFS_LABEL_SIZE];
+
+	__le64 cache_generation;
+	__le64 uuid_tree_generation;
+
+	/* future expansion */
+	__le64 reserved[30];
+	u8 sys_chunk_array[BTRFS_SYSTEM_CHUNK_ARRAY_SIZE];
+	struct btrfs_root_backup super_roots[BTRFS_NUM_BACKUP_ROOTS];
+} __attribute__ ((__packed__));
+
+#endif /* _GM_BTRFS_H */

--- a/src/gm_lvm2.c
+++ b/src/gm_lvm2.c
@@ -1,0 +1,66 @@
+/*
+ * gm_lvm2.c -- gpart Linux LVM2 physical volume guessing module
+ *
+ * gpart (c) 1999-2001 Michail Brzitwa <mb@ichabod.han.de>
+ * Guess PC-type hard disk partitions.
+ *
+ * gpart is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2, or (at your
+ * option) any later version.
+ *
+ * Created:   20.11.2015 <mwilck@arcor.de>
+ *
+ */
+
+#include <string.h>
+#include <errno.h>
+#include "gpart.h"
+#include "gm_lvm2.h"
+
+
+int lvm2_init(disk_desc *d,g_module *m)
+{
+	if ((d == 0) || (m == 0))
+		return (0);
+
+	m->m_desc = "Linux LVM2 physical volume";
+	return SECTOR_SIZE + LABEL_SIZE;
+}
+
+
+
+int lvm2_term(disk_desc *d)
+{
+	return (1);
+}
+
+
+
+int lvm2_gfun(disk_desc *d,g_module *m)
+{
+	struct label_header *lh;
+	struct pv_header *pvh;
+	dos_part_entry *pt = &m->m_part;
+	s64_t pv_size;
+	byte_t *p = d->d_sbuf + SECTOR_SIZE;
+
+	m->m_guess = GM_NO;
+	lh = (struct label_header*)p;
+	if (strncmp((char*)lh->id, LABEL_ID, sizeof(lh->id)) ||
+	    strncmp((char*)lh->type, LVM2_LABEL, sizeof(lh->type)))
+		return 1;
+
+	pvh = (struct pv_header*) ((char*)lh + le32toh(lh->offset_xl));
+	pv_size = le64toh(pvh->device_size_xl);
+	pv_size /=  d->d_ssize;
+	if (d->d_nsecs != 0 && pv_size > d->d_nsecs - d->d_nsb)
+		return 1;
+
+	m->m_guess = GM_YES;
+	pt->p_start = d->d_nsb;
+	pt->p_size = pv_size;
+	pt->p_typ = 0x8E;
+
+	return 1;
+}

--- a/src/gm_lvm2.h
+++ b/src/gm_lvm2.h
@@ -1,0 +1,65 @@
+/*
+ * gm_lvm2.h -- gpart Linux LVM physical volume guessing module header
+ *
+ * gpart (c) 1999-2001 Michail Brzitwa <mb@ichabod.han.de>
+ * Guess PC-type hard disk partitions.
+ *
+ * gpart is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2, or (at your
+ * option) any later version.
+ *
+ * Created:   19.11.2015 <mwilck@arcor.de>
+ * Modified:
+ *
+ */
+
+#ifndef _GM_LVM2_H
+#define _GM_LVM2_H
+#include <endian.h>
+
+/*
+ * structs & defines gathered from LVM2
+ */
+
+#if !defined(__FreeBSD__)
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+#endif
+
+#define ID_LEN 32
+#define SECTOR_SHIFT 9
+#define SECTOR_SIZE (1 << SECTOR_SHIFT)
+#define LABEL_ID "LABELONE"
+#define LABEL_SIZE SECTOR_SIZE
+#define LABEL_SCAN_SECTORS 4L
+#define LABEL_SCAN_SIZE (LABEL_SCAN_SECTORS << SECTOR_SHIFT)
+#define LVM2_LABEL "LVM2 001"
+
+/* On disk - 32 bytes */
+struct label_header {
+	int8_t id[8];		/* LABELONE */
+	uint64_t sector_xl;	/* Sector number of this label */
+	uint32_t crc_xl;	/* From next field to end of sector */
+	uint32_t offset_xl;	/* Offset from start of struct to contents */
+	int8_t type[8];		/* LVM2 001 */
+} __attribute__ ((packed));
+
+struct disk_locn {
+        uint64_t offset;        /* Offset in bytes to start sector */
+        uint64_t size;          /* Bytes */
+} __attribute__ ((packed));
+
+struct pv_header {
+	int8_t pv_uuid[ID_LEN];
+
+	/* This size can be overridden if PV belongs to a VG */
+	uint64_t device_size_xl;	/* Bytes */
+
+	/* NULL-terminated list of data areas followed by */
+	/* NULL-terminated list of metadata area headers */
+	struct disk_locn disk_areas_xl[0];	/* Two lists */
+} __attribute__ ((packed));
+
+#endif /* _GM_LVM2_H */

--- a/src/gmodules.h
+++ b/src/gmodules.h
@@ -66,6 +66,7 @@ g_module *g_mod_setweight(char *,float);
 	G_MODULE(minix) \
 	G_MODULE(beos) \
 	G_MODULE(ext2) \
+	G_MODULE(btrfs) \
 	G_MODULE(fat) \
 	G_MODULE(s86dl) \
 	G_MODULE(hmlvm) \

--- a/src/gmodules.h
+++ b/src/gmodules.h
@@ -69,6 +69,7 @@ g_module *g_mod_setweight(char *,float);
 	G_MODULE(fat) \
 	G_MODULE(s86dl) \
 	G_MODULE(hmlvm) \
+	G_MODULE(lvm2) \
 	G_MODULE(xfs)
 
 #define G_MODULE(mod)	int mod##_init(disk_desc *,g_module *),	\


### PR DESCRIPTION
Hello Baruch,

after a recent disk crash, I had the need to extend gpart with LVM2 and Btrfs detection capability. I wrote these two basic modules and tested them, LVM2 and Btrfs partitions were successfully detected on my systems. I didn't bother to put in too much intelligence for avoiding false positives, but both formats have rather complex magic strings that make random hits quite unlikely.

I've copied and only roughly modified code from both LVM2 and btrfs-progs, but they're both GPLv2 too, so that shoudldn't be a problem.

Regards,
Martin 

PS: I made some other changes in my "master" branch for speeding up gpart a bit. Feel free to have a look at those too. They worked well on my system.