### PR TITLE
l64seek.h: use off_t instead of loff_t

### DIFF
--- a/src/l64seek.h
+++ b/src/l64seek.h
@@ -27,7 +27,7 @@
  * offsets.
  */
 
-typedef loff_t off64_t;
+typedef off_t off64_t;
 typedef off64_t s64_t;
 
 off64_t l64seek(int fd, off64_t offset, int whence);


### PR DESCRIPTION
musl libc doesn't define ```loff_t```, but nowadays you could use ```off_t``` for 64-bit offsets

Bug: https://bugs.gentoo.org/715842
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
